### PR TITLE
Fix silent failure related to declining security updates in the response file.

### DIFF
--- a/infra-vars.yml
+++ b/infra-vars.yml
@@ -32,7 +32,8 @@ oracle_enable_recovery: 'true'
 oracle_storage_type: 'FILE_SYSTEM_STORAGE'
 oracle_dataloc: '{{ oracle_base }}/oradata'
 oracle_recoveryloc: '{{ oracle_base }}/recovery_area'
-oracle_decline_security_updates: 'yes'
+oracle_decline_security_updates: 'true'
+oracle_security_updates_via_myoraclesupport: 'false'
 hugepages_nr: 578
 
 # Username of the host machine. We use it for restart the vagrant machine

--- a/roles/oracle-install/templates/db_install.rsp.j2
+++ b/roles/oracle-install/templates/db_install.rsp.j2
@@ -420,7 +420,7 @@ MYORACLESUPPORT_PASSWORD=
 #
 # Example    : SECURITY_UPDATES_VIA_MYORACLESUPPORT=true
 #------------------------------------------------------------------------------
-SECURITY_UPDATES_VIA_MYORACLESUPPORT=
+SECURITY_UPDATES_VIA_MYORACLESUPPORT={{ oracle_security_updates_via_myoraclesupport }}
 
 #------------------------------------------------------------------------------
 # Specify whether user doesn't want to configure Security Updates.


### PR DESCRIPTION
Without the following changes, the installer simply failed without any error message:
- Set decline security updates response to 'true' rather than 'yes'
- Set security updates via myoracle to 'false'

I'm on SUSE SLES 12 (working on porting the Ansible scripts) but I'd be a little surprised if the distribution flavor matters for this particular error.
